### PR TITLE
Move Seestar functions into a SeestarClient class, remove global variables

### DIFF
--- a/seestar_run.py
+++ b/seestar_run.py
@@ -12,6 +12,7 @@ class SeestarClient:
         self.port = port
         self.cmdid = cmdid
         self.is_watch_events = True
+        self.is_debug = False
 
     def heartbeat(self): #I noticed a lot of pairs of test_connection followed by a get if nothing was going on
         self.json_message("test_connection")
@@ -40,6 +41,9 @@ class SeestarClient:
     def stop_watching(self):
         self.is_watch_events = False
 
+    def set_debug(self, is_debug):
+        self.is_debug = is_debug
+
     def send_message(self, data):
         try:
             self.socket.sendall(data.encode())  # TODO: would utf-8 or unicode_escaped help here
@@ -54,7 +58,7 @@ class SeestarClient:
             self.connect()
             data = self.socket.recv(1024 * 60)
         data = data.decode("utf-8")
-        if is_debug:
+        if self.is_debug:
             print("Received :", data)
         return data
         
@@ -79,7 +83,7 @@ class SeestarClient:
                         if state == "complete" or state == "fail":
                             self.set_op_state(state)
                     
-                    if is_debug:
+                    if self.is_debug:
                         print(parsed_data)
                         
                     first_index = msg_remainder.find("\r\n")
@@ -88,14 +92,14 @@ class SeestarClient:
     def json_message(self, instruction):
         data = {"id": self.get_cmdid(), "method": instruction}
         json_data = json.dumps(data)
-        if is_debug:
+        if self.is_debug:
             print("Sending %s" % json_data)
         self.send_message(json_data+"\r\n")
 
     def json_message2(self, data):
         if data:
             json_data = json.dumps(data)
-            if is_debug:
+            if self.is_debug:
                 print("Sending2 %s" % json_data)
             resp = self.send_message(json_data + "\r\n")
 
@@ -179,8 +183,6 @@ def parse_dec_to_float(dec_string):
     
     
 def main():
-    global is_debug
-    
     version_string = "1.0.0b1"
     print("seestar_run version: ", version_string)
 
@@ -227,6 +229,7 @@ def main():
 
     seestar_client = SeestarClient(HOST, PORT, cmdid)
     seestar_client.set_session_time(session_time)
+    seestar_client.set_debug(is_debug)
     s = seestar_client.connect()
 
     with s:

--- a/seestar_run.py
+++ b/seestar_run.py
@@ -33,6 +33,9 @@ class SeestarClient:
     def set_op_state(self, state):
         self.op_state = state
 
+    def set_session_time(self, session_time):
+        self.session_time = session_time
+
     def send_message(self, data):
         try:
             self.socket.sendall(data.encode())  # TODO: would utf-8 or unicode_escaped help here
@@ -141,7 +144,7 @@ class SeestarClient:
         
     def sleep_with_heartbeat(self):
         stacking_timer = 0
-        while stacking_timer < session_time:         # stacking time per segment
+        while stacking_timer < self.session_time:         # stacking time per segment
             stacking_timer += 1
             if stacking_timer % 5 == 0:
                 self.json_message("test_connection")
@@ -174,9 +177,6 @@ def parse_dec_to_float(dec_string):
 is_watch_events = True
     
 def main():
-    global HOST
-    global PORT
-    global session_time
     global is_watch_events
     global is_debug
     
@@ -225,6 +225,7 @@ def main():
     delta_Dec = 0.9
 
     seestar_client = SeestarClient(HOST, PORT, cmdid)
+    seestar_client.set_session_time(session_time)
     s = seestar_client.connect()
 
     with s:
@@ -244,12 +245,12 @@ def main():
             
         # print input requests
         print("received parameters:")
-        print("  ip address    : " + HOST)
+        print("  ip address    : " + seestar_client.ip)
         print("  target        : " + target_name)
         print("  RA            : ", center_RA)
         print("  Dec           : ", center_Dec)
         print("  use LP filter : ", is_use_LP_filter)
-        print("  session time  : ", session_time)
+        print("  session time  : ", seestar_client.session_time)
         print("  RA num panels : ", nRA)
         print("  Dec num panels: ", nDec)
         print("  RA offset x   : ", mRA)

--- a/seestar_run.py
+++ b/seestar_run.py
@@ -22,6 +22,11 @@ class SeestarClient:
         self.socket = s
         return s
 
+    def get_cmdid(self):
+        cmdid = self.cmdid
+        self.cmdid += 1
+        return cmdid
+
     def send_message(self, data):
         try:
             self.socket.sendall(data.encode())  # TODO: would utf-8 or unicode_escaped help here
@@ -70,9 +75,7 @@ class SeestarClient:
             time.sleep(1)
 
     def json_message(self, instruction):
-        global cmdid
-        data = {"id": cmdid, "method": instruction}
-        cmdid += 1
+        data = {"id": self.get_cmdid(), "method": instruction}
         json_data = json.dumps(data)
         if is_debug:
             print("Sending %s" % json_data)
@@ -87,11 +90,9 @@ class SeestarClient:
 
 
     def goto_target(self, ra, dec, target_name, is_lp_filter):
-        global cmdid
         print("going to target...")
         data = {}
-        data['id'] = cmdid
-        cmdid += 1
+        data['id'] = self.get_cmdid()
         data['method'] = 'iscope_start_view'
         params = {}
         params['mode'] = 'star'
@@ -103,11 +104,9 @@ class SeestarClient:
         self.json_message2(data)
         
     def start_stack(self):
-        global cmdid
         print("starting to stack...")
         data = {}
-        data['id'] = cmdid
-        cmdid += 1
+        data['id'] = self.get_cmdid()
         data['method'] = 'iscope_start_stack'
         params = {}
         params['restart'] = True
@@ -115,11 +114,9 @@ class SeestarClient:
         self.json_message2(data)
 
     def stop_stack(self):
-        global cmdid
         print("stop stacking...")
         data = {}
-        data['id'] = cmdid
-        cmdid += 1
+        data['id'] = self.get_cmdid()
         data['method'] = 'iscope_stop_view'
         params = {}
         params['stage'] = 'Stack'

--- a/seestar_run.py
+++ b/seestar_run.py
@@ -16,23 +16,25 @@ class SeestarClient:
         self.json_message("test_connection")
     #    json_message("scope_get_equ_coord")
 
+    def connect(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((self.ip, self.port))
+        self.socket = s
+        return s
+
     def send_message(self, data):
-        global s
         try:
-            s.sendall(data.encode())  # TODO: would utf-8 or unicode_escaped help here
+            self.socket.sendall(data.encode())  # TODO: would utf-8 or unicode_escaped help here
         except socket.error as e:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((HOST, PORT))
+            self.connect()
             self.send_message(data)
 
     def get_socket_msg(self):
-        global s
         try:
-            data = s.recv(1024 * 60)  # comet data is >50kb
+            data = self.socket.recv(1024 * 60)  # comet data is >50kb
         except socket.error as e:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((HOST, PORT))
-            data = s.recv(1024 * 60)
+            self.connect()
+            data = self.socket.recv(1024 * 60)
         data = data.decode("utf-8")
         if is_debug:
             print("Received :", data)
@@ -41,7 +43,6 @@ class SeestarClient:
     def receieve_message_thread_fn(self):
         global is_watch_events
         global op_state
-        global s
             
         msg_remainder = ""
         while is_watch_events:
@@ -175,8 +176,6 @@ def main():
     global HOST
     global PORT
     global session_time
-    global s
-    global cmdid
     global is_watch_events
     global is_debug
     
@@ -225,9 +224,8 @@ def main():
     delta_Dec = 0.9
 
     seestar_client = SeestarClient(HOST, PORT, cmdid)
+    s = seestar_client.connect()
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.connect((HOST, PORT))
     with s:
         
         # flush the socket input stream for garbage

--- a/seestar_run.py
+++ b/seestar_run.py
@@ -27,6 +27,12 @@ class SeestarClient:
         self.cmdid += 1
         return cmdid
 
+    def get_op_state(self):
+        return self.op_state
+
+    def set_op_state(self, state):
+        self.op_state = state
+
     def send_message(self, data):
         try:
             self.socket.sendall(data.encode())  # TODO: would utf-8 or unicode_escaped help here
@@ -47,7 +53,6 @@ class SeestarClient:
         
     def receieve_message_thread_fn(self):
         global is_watch_events
-        global op_state
             
         msg_remainder = ""
         while is_watch_events:
@@ -66,7 +71,7 @@ class SeestarClient:
                         state = parsed_data['state']
                         print("AutoGoto state: %s" % state)
                         if state == "complete" or state == "fail":
-                            op_state = state
+                            self.set_op_state(state)
                     
                     if is_debug:
                         print(parsed_data)
@@ -124,10 +129,9 @@ class SeestarClient:
         self.json_message2(data)
 
     def wait_end_op(self):
-        global op_state
-        op_state = "working"
+        self.set_op_state('working')
         heartbeat_timer = 0
-        while op_state == "working":
+        while self.get_op_state() == "working":
             heartbeat_timer += 1
             if heartbeat_timer > 5:
                 heartbeat_timer = 0
@@ -279,7 +283,7 @@ def main():
                 
                 time.sleep(3)
                 
-                if op_state == "complete":
+                if seestar_client.get_op_state() == "complete":
                     seestar_client.start_stack()    
                     seestar_client.sleep_with_heartbeat()
                     seestar_client.stop_stack()

--- a/seestar_run.py
+++ b/seestar_run.py
@@ -11,6 +11,7 @@ class SeestarClient:
         self.ip = ip
         self.port = port
         self.cmdid = cmdid
+        self.is_watch_events = True
 
     def heartbeat(self): #I noticed a lot of pairs of test_connection followed by a get if nothing was going on
         self.json_message("test_connection")
@@ -36,6 +37,9 @@ class SeestarClient:
     def set_session_time(self, session_time):
         self.session_time = session_time
 
+    def stop_watching(self):
+        self.is_watch_events = False
+
     def send_message(self, data):
         try:
             self.socket.sendall(data.encode())  # TODO: would utf-8 or unicode_escaped help here
@@ -55,10 +59,9 @@ class SeestarClient:
         return data
         
     def receieve_message_thread_fn(self):
-        global is_watch_events
             
         msg_remainder = ""
-        while is_watch_events:
+        while self.is_watch_events:
             #print("checking for msg")
             data = self.get_socket_msg()
             if data:
@@ -174,10 +177,8 @@ def parse_dec_to_float(dec_string):
 
     return dec_decimal
     
-is_watch_events = True
     
 def main():
-    global is_watch_events
     global is_debug
     
     version_string = "1.0.0b1"
@@ -298,7 +299,7 @@ def main():
         
         
     print("Finished seestar_run")
-    is_watch_events = False
+    seestar_client.stop_watching()
     get_msg_thread.join(timeout=5)
     sys.exit()
     


### PR DESCRIPTION
This PR moves most of the Seestar functionality into its own client class and gets rid of the existing global variables. In general, global variables can make it difficult to understand how different parts of the code are interacting, and having defined interfaces (like the `get_` and `set_` methods added here) make it easier to read the code, even if it's a bit more verbose.

This doesn't change any behavior, it's just aesthetic, and slightly better for long-term maintainability and allowing new folks to join onto the project. There aren't really that many lines that are actually changed (besides being tabbed in), git just makes it look like there are. 🤷 